### PR TITLE
fix: Home page logo and text shift on initial load #18

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,15 +8,45 @@ export default function Home() {
       {/* Hero Section */}
       <section className="relative h-[60vh] pt-10">
         <div className="relative z-10 flex flex-col items-center justify-center h-full text-white text-center px-4">
-          <div className="relative w-48 h-48 md:w-64 md:h-64 mb-8">
-            <Image
-              src="/images/lotus-logo.png"
-              alt="EYP Logo"
-              fill
-              className="object-contain"
-              priority
-            />
-          </div>
+          <div className="mb-8">
+
+            {/* Mobile */}
+            <div className="block sm:hidden">
+              <Image
+                src="/images/lotus-logo.png"
+                alt="EYP Logo"
+                width={115}
+                height={115}
+                className="object-contain"
+                priority
+              />
+            </div>
+
+            {/* Tablet */}
+            <div className="hidden sm:block md:hidden">
+              <Image
+                src="/images/lotus-logo.png"
+                alt="EYP Logo"
+                width={140}
+                height={140}
+                className="object-contain"
+                priority
+              />
+            </div>
+
+            {/* Desktop */}
+            <div className="hidden md:block">
+              <Image
+                src="/images/lotus-logo.png"
+                alt="EYP Logo"
+                width={160}
+                height={160}
+                className="object-contain"
+                priority
+              />
+            </div>
+
+        </div>
           <h1 className="text-5xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-white via-pink-200 to-white bg-clip-text text-transparent">
             EYP Summer Training Camp
           </h1>


### PR DESCRIPTION
# ✅ Pull Request: Fix FOUC on Homepage Logo (#18)

## Summary  
This PR resolves issue #18 by preventing the logo and intro text from shifting on initial page load. The problem was caused by the use of the Next.js `Image` component with `fill`, which relies on the container’s dimensions that are not immediately available during SSR. This resulted in a flash-of-unstyled-content (FOUC).

## What Was Done
- Replaced `Image` using `fill` with intrinsic sizing (`width` and `height`) to ensure layout space is reserved at render time.
- Implemented responsive logo sizes using Tailwind’s `hidden` / `block` utilities for different breakpoints (mobile, tablet, desktop).
- This prevents layout shifts and avoids relying on JavaScript to render image dimensions.

## Before
- Logo briefly appears oversized on first render.
- Intro text is pushed down, then snaps into place after hydration.

## After
- Logo renders at the correct size immediately on first load
- Intro text remains properly positioned with no visible layout shift.

## Thank you 😅🙌