### PR TITLE
Make mobile menu toggle visible with label

### DIFF
--- a/src/components/Navigation/Navbar.tsx
+++ b/src/components/Navigation/Navbar.tsx
@@ -73,6 +73,7 @@ export default function Navbar() {
                 ) : (
                   <svg className="block h-6 w-6"/>
                 )}
+                <span className="ml-2 text-sm font-medium">Menu</span>
               </button>
             </div>
           </div>


### PR DESCRIPTION
Closes #30\n\nAdded a visible “Menu” label next to the hamburger icon and an aria-label for accessibility.