### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/scavenger-hunt/page.tsx
+++ b/src/app/scavenger-hunt/page.tsx
@@ -189,8 +189,14 @@ export default function ScavengerHuntPage() {
                       className="sr-only"
                       onChange={(e) => {
                         const f = e.target.files?.[0] ?? null;
-                        setFile(f);
-                        setPreview(f ? URL.createObjectURL(f) : '');
+                        if (f && f.type.startsWith('image/')) {
+                          setFile(f);
+                          setPreview(URL.createObjectURL(f));
+                        } else {
+                          setFile(null);
+                          setPreview('');
+                          console.error('Invalid file type. Please upload an image.');
+                        }
                       }}
                     />
                   </div>


### PR DESCRIPTION
Potential fix for [https://github.com/Ph4ntomByte/Summer_Training_Camp/security/code-scanning/2](https://github.com/Ph4ntomByte/Summer_Training_Camp/security/code-scanning/2)

To fix the issue, we need to validate the file type before setting the `preview` variable. This ensures that only image files are used as the source for the `<img>` tag. Specifically:
1. Check the MIME type of the file object (`f.type`) to ensure it starts with `image/`.
2. If the file type is invalid, do not set the `preview` variable and optionally display an error message to the user.

Changes will be made in the `onChange` handler for the `<input>` element on line 190.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
