### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^9.16.0",
-    "s3": "^2.0.0"
+    "s3": "^2.0.0",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/scavenger-hunt/page.tsx
+++ b/src/app/scavenger-hunt/page.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 'use client';
 import React, { useState, useRef, FormEvent, useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import { SectionHeading } from '@/components/SectionHeading/SectionHeading';
 import { useRouter } from 'next/navigation';
 
@@ -176,7 +177,7 @@ export default function ScavengerHuntPage() {
                         ${submitting ? 'opacity-60 pointer-events-none' : ''}`}
                     >
                       {preview ? (
-                        <img src={preview} className="max-h-full object-contain" />
+                        <img src={preview} alt="Uploaded preview" className="max-h-full object-contain" />
                       ) : (
                         <span className="text-white/80">Click or drag file here</span>
                       )}
@@ -191,7 +192,8 @@ export default function ScavengerHuntPage() {
                         const f = e.target.files?.[0] ?? null;
                         if (f && f.type.startsWith('image/')) {
                           setFile(f);
-                          setPreview(URL.createObjectURL(f));
+                          const sanitizedPreview = DOMPurify.sanitize(URL.createObjectURL(f));
+                          setPreview(sanitizedPreview);
                         } else {
                           setFile(null);
                           setPreview('');


### PR DESCRIPTION
Potential fix for [https://github.com/Ph4ntomByte/Summer_Training_Camp/security/code-scanning/2](https://github.com/Ph4ntomByte/Summer_Training_Camp/security/code-scanning/2)

To address the issue, we need to ensure that the `preview` variable is sanitized before being used as the `src` attribute of the `<img>` tag. A safe approach is to validate the file type and ensure that the generated URL is used securely. Additionally, we can use a library like `DOMPurify` to sanitize the URL if necessary.

**Steps to fix:**
1. Validate the file type explicitly before calling `URL.createObjectURL`.
2. Use a library like `DOMPurify` to sanitize the generated URL before assigning it to `preview`.
3. Update the code on line 194 to include sanitization logic.
4. Ensure that the `<img>` tag on line 179 uses the sanitized `preview` value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
